### PR TITLE
Upgrade Chart to Support RapidPro version 8

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v7.4.2"
+appVersion: "v8.0.1"
 
 dependencies:
   - name: redis

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -36,9 +36,7 @@ Common labels
 {{- define "rapidpro.labels" -}}
 helm.sh/chart: {{ include "rapidpro.chart" . }}
 {{ include "rapidpro.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/version: {{ .Values.rapidpro.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -48,7 +46,7 @@ Mailroom labels
 {{- define "mailroom.labels" -}}
 helm.sh/chart: {{ include "rapidpro.chart" . }}
 {{ include "mailroom.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.mailroom.image.tag | quote }}
+app.kubernetes.io/version: {{ .Values.mailroom.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -58,7 +56,7 @@ Courier labels
 {{- define "courier.labels" -}}
 helm.sh/chart: {{ include "rapidpro.chart" . }}
 {{ include "courier.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.courier.image.tag | quote }}
+app.kubernetes.io/version: {{ .Values.courier.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -68,7 +66,7 @@ Indexer labels
 {{- define "indexer.labels" -}}
 helm.sh/chart: {{ include "rapidpro.chart" . }}
 {{ include "indexer.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.indexer.image.tag | quote }}
+app.kubernetes.io/version: {{ .Values.indexer.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -79,7 +77,7 @@ Archiver labels
 {{- if .Values.archiver.enabled }}
 helm.sh/chart: {{ include "rapidpro.chart" . }}
 {{ include "archiver.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.archiver.image.tag | quote }}
+app.kubernetes.io/version: {{ .Values.archiver.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -24,9 +24,9 @@ smtp:
 # Values for the RapidPro Django application
 rapidpro:
   image:
-    repository: praekeltfoundation/rapidpro
+    repository: docker.io/onaio/rapidpro
     pullPolicy: IfNotPresent
-    tag: null
+    tag: v8.0.1
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -83,10 +83,10 @@ mailroom:
     port: 8090
     targetPort: 8090
   image:
-    repository: praekeltfoundation/mailroom
+    repository: docker.io/onaio/mailroom
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: null
+    tag: v8.0.0
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -107,10 +107,10 @@ mailroom:
 
 courier:
   image:
-    repository: praekeltfoundation/courier
+    repository: docker.io/onaio/courier
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: null
+    tag: v8.0.2
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -133,10 +133,10 @@ courier:
 
 indexer:
   image:
-    repository: praekeltfoundation/rp-indexer
+    repository: docker.io/onaio/rp-indexer
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: null
+    tag: v8.0.0
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -158,8 +158,8 @@ archiver:
   enabled: false
   image:
     pullPolicy: IfNotPresent
-    repository: docker.io/praekeltfoundation/rp-archiver
-    tag: v7.0.0
+    repository: docker.io/onaio/rp-archiver
+    tag: v8.0.0
   autoscaling:
     enabled: false
     minReplicas: 1


### PR DESCRIPTION
- Upgrade RapidPro and microservice default version
- Update chart version
- Use Ona images that support both arm and x86 architecture